### PR TITLE
Conformance to overlay spec

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,0 +1,1 @@
+niftyled


### PR DESCRIPTION
An overlay needs to have the profiles/repo_name file to identify itself. This is used by layman, portage, egencache and other portage tools. See for example http://wiki.gentoo.org/wiki/Repository_format/profiles/repo_name 
